### PR TITLE
feat(dashboard): ✨ enable Google authentication provider in sign-in process

### DIFF
--- a/src/pages/api/auth/signin.ts
+++ b/src/pages/api/auth/signin.ts
@@ -3,7 +3,7 @@ import type { Provider } from "@supabase/supabase-js";
 import type { APIRoute } from "astro";
 
 export const POST = (async ({ request, cookies, url, redirect }) => {
-  const VALID_PROVIDERS: Provider[] = ["github"];
+  const VALID_PROVIDERS: Provider[] = ["github", "google"];
   const formData = await request.formData();
 
   const provider = formData.get("provider") as Provider;

--- a/src/pages/signin.astro
+++ b/src/pages/signin.astro
@@ -22,8 +22,7 @@ const description = "Acceso exclusivo para administradores autorizados. El acces
       </CardHeader>
 
       <CardContent class="space-y-6">
-        <form action="/api/auth/signin" method="POST">
-          <input type="hidden" name="provider" value="github" />
+        <form action="/api/auth/signin" method="POST" class="space-y-2">
           <input type="hidden" name="redirectTo">
 
           <Button
@@ -31,14 +30,28 @@ const description = "Acceso exclusivo para administradores autorizados. El acces
             size="lg"
             variant="outline"
             class="w-full text-base"
+            name="provider"
+            value="github"
           >
             <Icon name="devicon:github"/>
             Continuar con GitHub
           </Button>
+
+          <Button
+            type="submit"
+            size="lg"
+            variant="outline"
+            class="w-full text-base"
+            name="provider"
+            value="google"
+          >
+            <Icon name="devicon:google"/>
+            Continuar con Google
+          </Button>
         </form>
 
         <div class="before:border-on-muted relative flex justify-center text-xs uppercase before:absolute before:top-1/2 before:w-full before:border-t before:border-border">
-          <span class="text-on-muted bg-card z-0 px-2">Acceso restringido</span>
+          <span class="text-on-muted bg-sidebar z-0 px-2">Acceso restringido</span>
         </div>
 
         <div class="bg-muted/50 rounded-lg p-4 space-y-2">
@@ -64,8 +77,6 @@ const description = "Acceso exclusivo para administradores autorizados. El acces
     const input = document.querySelector('input[name="redirectTo"]');
     const params = new URLSearchParams(window.location.search);
     const redirectTo = params.get('redirectTo') || '';
-    if (input && redirectTo) {
-      input.value = redirectTo;
-    }
+    if (input && redirectTo) input.value = redirectTo;
   </script>
 </Body>


### PR DESCRIPTION
This pull request adds support for Google as an authentication provider alongside GitHub in the sign-in flow. The changes update both the backend API and the frontend sign-in page to allow users to sign in using either provider.

Authentication provider support:

* Updated the `VALID_PROVIDERS` array in `src/pages/api/auth/signin.ts` to include `"google"` in addition to `"github"`, enabling Google as a valid authentication provider.

Frontend sign-in form updates:

* Modified the sign-in form in `src/pages/signin.astro` to present two sign-in buttons: one for GitHub and one for Google. Each button submits the form with the appropriate provider value, allowing users to choose their authentication provider.
* Slightly refactored the JavaScript handling the `redirectTo` input to a more concise form.

Styling adjustment:

* Changed the background class for the "Acceso restringido" label from `bg-card` to `bg-sidebar` for improved visual consistency.…sign-in process